### PR TITLE
Add Android demo and ONNX export

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,7 @@ This project is based on the following repositories:
 - [MMDetection](https://github.com/open-mmlab/mmdetection)
 - [Ultralytics YOLO](https://github.com/ultralytics/yolov5)
 - [Road Damage Detector](https://github.com/sekilab/RoadDamageDetector)
+
+## Android Example
+
+A minimal Android application is provided in the `android` directory. It demonstrates how to run the exported YOLOv10 ONNX model on device using ONNX Runtime and CameraX. Follow the instructions in `android/README.md` to export the weights and build the APK.

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,32 @@
+# FRDC Road Damage Detection Android App
+
+This directory contains a minimal Android application that demonstrates how to run the road damage detection model on a mobile device using ONNX Runtime.
+
+## Prerequisites
+- Android Studio Bumblebee or newer
+- Android SDK and NDK installed
+- Android device or emulator running Android 8.0+
+
+## Exporting the Model
+Export the YOLOv10 model to ONNX before building the app:
+
+```bash
+# Install ultralytics if not already installed
+pip install ultralytics
+
+# Export to onnx
+yolo export model=<path_to_your_weight>.pt format=onnx opset=13 simplify
+```
+
+Copy the resulting `*.onnx` file to `app/src/main/assets/model.onnx`.
+
+## Building
+Open the `android` directory in Android Studio and build the `app` module. The application uses CameraX to capture frames and runs inference with ONNX Runtime. Post-processing and drawing of bounding boxes should be implemented in `MainActivity.kt`.
+
+## Functionality
+- Capture live camera frames using CameraX
+- Run the ONNX model on each frame
+- (TODO) Draw detection boxes on the preview
+
+## Notes
+This example provides a starting point. For better performance and full features (reading images/videos from storage, saving results), additional development is required.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,48 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    compileSdk 34
+
+    defaultConfig {
+        applicationId "com.frdc.rdd"
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+
+        ndk {
+            abiFilters "arm64-v8a", "armeabi-v7a"
+        }
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.8.22"
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.camera:camera-core:1.3.3'
+    implementation 'androidx.camera:camera-camera2:1.3.3'
+    implementation 'androidx.camera:camera-lifecycle:1.3.3'
+    implementation 'androidx.camera:camera-view:1.3.3'
+    implementation 'ai.onnxruntime:onnxruntime-android:1.16.3'
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.frdc.rdd">
+
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="FRDC RDD"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/android/app/src/main/java/com/frdc/rdd/InferenceHelper.kt
+++ b/android/app/src/main/java/com/frdc/rdd/InferenceHelper.kt
@@ -1,0 +1,49 @@
+package com.frdc.rdd
+
+import android.content.Context
+import android.graphics.Bitmap
+import ai.onnxruntime.OnnxTensor
+import ai.onnxruntime.OrtEnvironment
+import ai.onnxruntime.OrtSession
+import java.nio.FloatBuffer
+
+class InferenceHelper(context: Context) {
+    private val env = OrtEnvironment.getEnvironment()
+    private val session: OrtSession
+
+    init {
+        val modelBytes = context.assets.open("model.onnx").readBytes()
+        session = env.createSession(modelBytes)
+    }
+
+    fun run(bitmap: Bitmap): FloatArray {
+        val input = preprocess(bitmap)
+        val tensor = OnnxTensor.createTensor(env, input, longArrayOf(1, 3, bitmap.height.toLong(), bitmap.width.toLong()))
+        val results = session.run(mapOf(session.inputNames.iterator().next() to tensor))
+        val output = results[0].value as Array<FloatArray>
+        results.close()
+        tensor.close()
+        return output.flatten().toFloatArray()
+    }
+
+    private fun preprocess(bitmap: Bitmap): FloatBuffer {
+        val w = bitmap.width
+        val h = bitmap.height
+        val floatBuffer = FloatBuffer.allocate(3 * w * h)
+        val pixels = IntArray(w * h)
+        bitmap.getPixels(pixels, 0, w, 0, 0, w, h)
+        for (y in 0 until h) {
+            for (x in 0 until w) {
+                val px = pixels[y * w + x]
+                val r = (px shr 16 and 0xFF) / 255f
+                val g = (px shr 8 and 0xFF) / 255f
+                val b = (px and 0xFF) / 255f
+                floatBuffer.put(r)
+                floatBuffer.put(g)
+                floatBuffer.put(b)
+            }
+        }
+        floatBuffer.rewind()
+        return floatBuffer
+    }
+}

--- a/android/app/src/main/java/com/frdc/rdd/MainActivity.kt
+++ b/android/app/src/main/java/com/frdc/rdd/MainActivity.kt
@@ -1,0 +1,100 @@
+package com.frdc.rdd
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.os.Bundle
+import android.util.Size
+import androidx.appcompat.app.AppCompatActivity
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
+import kotlinx.android.synthetic.main.activity_main.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.util.concurrent.Executors
+
+class MainActivity : AppCompatActivity() {
+
+    private lateinit var helper: InferenceHelper
+    private val executor = Executors.newSingleThreadExecutor()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        if (allPermissionsGranted()) {
+            startCamera()
+        } else {
+            ActivityCompat.requestPermissions(this, REQUIRED_PERMISSIONS, REQUEST_CODE_PERMISSIONS)
+        }
+
+        helper = InferenceHelper(this)
+    }
+
+    private fun startCamera() {
+        val cameraProviderFuture = ProcessCameraProvider.getInstance(this)
+        cameraProviderFuture.addListener({
+            val cameraProvider = cameraProviderFuture.get()
+            val preview = androidx.camera.core.Preview.Builder().build().also {
+                it.setSurfaceProvider(previewView.surfaceProvider)
+            }
+
+            val imageAnalyzer = ImageAnalysis.Builder()
+                .setTargetResolution(Size(640, 480))
+                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                .build()
+
+            imageAnalyzer.setAnalyzer(executor) { image ->
+                processImage(image)
+            }
+
+            val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
+            cameraProvider.unbindAll()
+            cameraProvider.bindToLifecycle(this, cameraSelector, preview, imageAnalyzer)
+        }, ContextCompat.getMainExecutor(this))
+    }
+
+    private fun processImage(image: ImageProxy) {
+        val bitmap = image.toBitmap() ?: return
+        lifecycleScope.launch(Dispatchers.Default) {
+            val outputs = helper.run(bitmap)
+            // TODO: Post-process outputs to draw bounding boxes on preview
+        }
+        image.close()
+    }
+
+    private fun allPermissionsGranted() = REQUIRED_PERMISSIONS.all {
+        ContextCompat.checkSelfPermission(baseContext, it) == PackageManager.PERMISSION_GRANTED
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == REQUEST_CODE_PERMISSIONS) {
+            if (allPermissionsGranted()) {
+                startCamera()
+            } else {
+                finish()
+            }
+        }
+    }
+
+    companion object {
+        private const val REQUEST_CODE_PERMISSIONS = 10
+        private val REQUIRED_PERMISSIONS = arrayOf(Manifest.permission.CAMERA)
+    }
+}
+
+fun ImageProxy.toBitmap(): Bitmap? {
+    val planeProxy = this.planes[0]
+    val buffer = planeProxy.buffer
+    val bytes = ByteArray(buffer.remaining())
+    buffer.get(bytes)
+    val bitmap = Bitmap.createBitmap(this.width, this.height, Bitmap.Config.ARGB_8888)
+    bitmap.copyPixelsFromBuffer(java.nio.ByteBuffer.wrap(bytes))
+    return bitmap
+}

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.camera.view.PreviewView
+        android:id="@+id/previewView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,16 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.1.2'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'frdc_rdd_android'
+include ':app'

--- a/tools/export_onnx.py
+++ b/tools/export_onnx.py
@@ -1,0 +1,14 @@
+import argparse
+import os
+from ultralytics import YOLOv10
+
+parser = argparse.ArgumentParser(description="Export YOLOv10 model to ONNX")
+parser.add_argument("--model", required=True, help="Path to .pt weight")
+parser.add_argument("--output", default="model.onnx", help="Output onnx file")
+args = parser.parse_args()
+
+model = YOLOv10(args.model)
+onnx_path = model.export(format="onnx", opset=13, simplify=True)
+final_path = os.path.abspath(args.output)
+os.rename(onnx_path, final_path)
+print(f"ONNX model saved to {final_path}")


### PR DESCRIPTION
## Summary
- add an `android` directory with a minimal CameraX/ONNX Runtime demo
- provide a helper script to export YOLOv10 weights to ONNX
- document the Android demo in the root README

## Testing
- `python -m py_compile tools/export_onnx.py`

------
https://chatgpt.com/codex/tasks/task_e_683f5bec62c0832c9a7aabf79d8c729a